### PR TITLE
Add support for multiple variant images

### DIFF
--- a/assets/product-card.js
+++ b/assets/product-card.js
@@ -188,7 +188,7 @@ export class ProductCard extends Component {
 
   /**
    * Hide the variant images that are not for the selected variant.
-   */
+  */
   #updateVariantImages() {
     const { slideshow } = this.refs;
     if (!this.variantPicker?.selectedOption) {
@@ -196,14 +196,19 @@ export class ProductCard extends Component {
     }
 
     const selectedImageId = this.variantPicker?.selectedOption.dataset.optionMediaId;
+    const variantId = this.variantPicker?.selectedOption.dataset.variantId;
 
-    if (slideshow && selectedImageId) {
+    if (slideshow && (selectedImageId || variantId)) {
       const { slides = [] } = slideshow.refs;
 
       for (const slide of slides) {
         if (slide.getAttribute('variant-image') == null) continue;
-
-        slide.hidden = slide.getAttribute('slide-id') !== selectedImageId;
+        const variantIds = slide.dataset.variantIds?.split(',');
+        if (variantIds && variantIds.length > 0) {
+          slide.hidden = !variantIds.includes(variantId);
+        } else {
+          slide.hidden = slide.getAttribute('slide-id') !== selectedImageId;
+        }
       }
     }
   }
@@ -306,6 +311,18 @@ export class ProductCard extends Component {
     }
 
     const id = this.variantPicker.selectedOption.dataset.optionMediaId;
+    const variantId = this.variantPicker.selectedOption.dataset.variantId;
+
+    const { slides = [] } = slideshow.refs;
+    const firstVariantSlide = slides.find(
+      (s) => s.dataset.variantIds?.split(',').includes(variantId)
+    );
+
+    if (firstVariantSlide) {
+      slideshow.select({ id: firstVariantSlide.getAttribute('slide-id') }, undefined, { animate: false });
+      return;
+    }
+
     if (!id) {
       slideshow.previous(undefined, { animate: false });
       return;

--- a/snippets/card-gallery.liquid
+++ b/snippets/card-gallery.liquid
@@ -164,6 +164,10 @@
         {% assign hidden = false %}
         {% if variant_images contains media.src %}
           {% assign attributes = 'variant-image' %}
+          {% assign variant_ids = media.variant_ids | default: media.preview_image.variant_ids %}
+          {% if variant_ids != blank %}
+            {% capture attributes %}{{ attributes }} data-variant-ids="{{ variant_ids | join: ',' }}"{% endcapture %}
+          {% endif %}
           {% unless forloop.first and media.src == selected_variant_image or has_generic_media == false %}
             {% assign hidden = true %}
           {% endunless %}


### PR DESCRIPTION
## Summary
- keep variant images in product cards when a variant has more than one image
- store variant IDs for card gallery slides
- show/hide slides based on variant IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688296f47d508326b3665cb2c43ae3ee