### PR TITLE
Enable alt-based variant image filtering

### DIFF
--- a/assets/product-card.js
+++ b/assets/product-card.js
@@ -188,7 +188,7 @@ export class ProductCard extends Component {
 
   /**
    * Hide the variant images that are not for the selected variant.
-   */
+  */
   #updateVariantImages() {
     const { slideshow } = this.refs;
     if (!this.variantPicker?.selectedOption) {
@@ -196,14 +196,31 @@ export class ProductCard extends Component {
     }
 
     const selectedImageId = this.variantPicker?.selectedOption.dataset.optionMediaId;
+    const variantId = this.variantPicker?.selectedOption.dataset.variantId;
+    const variantName = (
+      this.variantPicker?.selectedOption.getAttribute('aria-label') ||
+      this.variantPicker?.selectedOption.textContent ||
+      ''
+    )
+      .trim()
+      .toLowerCase();
 
-    if (slideshow && selectedImageId) {
+    if (slideshow && (selectedImageId || variantId)) {
       const { slides = [] } = slideshow.refs;
 
       for (const slide of slides) {
         if (slide.getAttribute('variant-image') == null) continue;
-
-        slide.hidden = slide.getAttribute('slide-id') !== selectedImageId;
+        const variantIds = slide.dataset.variantIds?.split(',');
+        const altName = (slide.dataset.variantAlt || '').toLowerCase();
+        if (variantIds && variantIds.length > 0) {
+          slide.hidden =
+            !variantIds.includes(variantId) &&
+            !(variantName && altName.includes(variantName));
+        } else if (variantName) {
+          slide.hidden = !altName.includes(variantName);
+        } else {
+          slide.hidden = slide.getAttribute('slide-id') !== selectedImageId;
+        }
       }
     }
   }
@@ -306,6 +323,30 @@ export class ProductCard extends Component {
     }
 
     const id = this.variantPicker.selectedOption.dataset.optionMediaId;
+    const variantId = this.variantPicker.selectedOption.dataset.variantId;
+    const variantName = (
+      this.variantPicker.selectedOption.getAttribute('aria-label') ||
+      this.variantPicker.selectedOption.textContent ||
+      ''
+    )
+      .trim()
+      .toLowerCase();
+
+    const { slides = [] } = slideshow.refs;
+    const firstVariantSlide = slides.find((s) => {
+      const ids = s.dataset.variantIds?.split(',');
+      const altName = (s.dataset.variantAlt || '').toLowerCase();
+      return (
+        (ids && ids.includes(variantId)) ||
+        (variantName && altName.includes(variantName))
+      );
+    });
+
+    if (firstVariantSlide) {
+      slideshow.select({ id: firstVariantSlide.getAttribute('slide-id') }, undefined, { animate: false });
+      return;
+    }
+
     if (!id) {
       slideshow.previous(undefined, { animate: false });
       return;

--- a/assets/product-card.js
+++ b/assets/product-card.js
@@ -187,6 +187,17 @@ export class ProductCard extends Component {
   }
 
   /**
+   * Decodes HTML entities from a string.
+   * @param {string} html
+   * @returns {string}
+   */
+  #decodeHtml(html) {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    return div.textContent || '';
+  }
+
+  /**
    * Hide the variant images that are not for the selected variant.
   */
   #updateVariantImages() {
@@ -211,7 +222,7 @@ export class ProductCard extends Component {
       for (const slide of slides) {
         if (slide.getAttribute('variant-image') == null) continue;
         const variantIds = slide.dataset.variantIds?.split(',');
-        const altName = (slide.dataset.variantAlt || '').toLowerCase();
+        const altName = this.#decodeHtml(slide.dataset.variantAlt || '').toLowerCase();
         if (variantIds && variantIds.length > 0) {
           slide.hidden =
             !variantIds.includes(variantId) &&
@@ -335,7 +346,7 @@ export class ProductCard extends Component {
     const { slides = [] } = slideshow.refs;
     const firstVariantSlide = slides.find((s) => {
       const ids = s.dataset.variantIds?.split(',');
-      const altName = (s.dataset.variantAlt || '').toLowerCase();
+      const altName = this.#decodeHtml(s.dataset.variantAlt || '').toLowerCase();
       return (
         (ids && ids.includes(variantId)) ||
         (variantName && altName.includes(variantName))

--- a/snippets/card-gallery.liquid
+++ b/snippets/card-gallery.liquid
@@ -155,6 +155,7 @@
         {% endif %}
 
         {% assign attributes = '' %}
+        {% assign variant_alt = media.alt | escape %}
         {% capture slideshow_children %}
           {%- render 'product-media', media: media, sizes: sizes, loading: loading, preview_image_only: true -%}
         {% endcapture %}
@@ -164,10 +165,15 @@
         {% assign hidden = false %}
         {% if variant_images contains media.src %}
           {% assign attributes = 'variant-image' %}
+          {% assign variant_ids = media.variant_ids | default: media.preview_image.variant_ids %}
+          {% if variant_ids != blank %}
+            {% capture attributes %}{{ attributes }} data-variant-ids="{{ variant_ids | join: ',' }}"{% endcapture %}
+          {% endif %}
           {% unless forloop.first and media.src == selected_variant_image or has_generic_media == false %}
             {% assign hidden = true %}
           {% endunless %}
         {% endif %}
+        {% capture attributes %}{{ attributes }} data-variant-alt="{{ variant_alt }}"{% endcapture %}
         {% render 'slideshow-slide', slide_id: media.id, index: forloop.index, children: slideshow_children, class: class, attributes: attributes, hidden: hidden, media_fit: media_fit %}
       {% endfor %}
     {% endcapture %}


### PR DESCRIPTION
## Summary
- tag product images with their alt text
- use alt text to decide which variant images to show

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688296f47d508326b3665cb2c43ae3ee