### PR TITLE
feat: hide variant images by alt tag

### DIFF
--- a/blocks/_product-media-gallery.liquid
+++ b/blocks/_product-media-gallery.liquid
@@ -13,7 +13,27 @@
   assign first_3d_model = selected_product.media | where: 'media_type', 'model' | first
 
   if block.settings.hide_variants
-    assign variant_images = product.images | where: 'attached_to_variant?', true | map: 'src'
+    assign variant_images = ''
+    assign variant_names = ''
+    for option in selected_product.options_with_values
+      for value in option.values
+        assign variant_names = variant_names | append: value.name | append: ','
+      endfor
+    endfor
+    assign variant_names = variant_names | downcase | split: ',' | uniq | compact
+
+    assign selected_variant_options = selected_product.selected_or_first_available_variant.options | join: ',' | downcase | split: ','
+
+    for image in selected_product.images
+      assign alt_text = image.alt | downcase
+      if image.attached_to_variant? or variant_names contains alt_text
+        assign variant_images = variant_images | append: image.src | append: ','
+        if selected_variant_media == blank and selected_variant_options contains alt_text
+          assign selected_variant_media = image
+        endif
+      endif
+    endfor
+    assign variant_images = variant_images | split: ',' | uniq | compact
   endif
 
   if block.settings.slideshow_controls_style == 'thumbnails'


### PR DESCRIPTION
## Summary
- hide variant-specific images whose alt text matches variant names
- set selected variant media from alt-tagged images when variant media not attached

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688e2ff9a64c832689e3d78a3f6177c4